### PR TITLE
Refactor IntervalBatcher for performance

### DIFF
--- a/src/InfluxDB.Collector/Configuration/AggregateEmitter.cs
+++ b/src/InfluxDB.Collector/Configuration/AggregateEmitter.cs
@@ -19,5 +19,11 @@ namespace InfluxDB.Collector.Configuration
             foreach (var emitter in _emitters)
                 emitter.Emit(points);
         }
+
+        public void Emit(PointData point)
+        {
+            foreach (var emitter in _emitters)
+                emitter.Emit(point);
+        }
     }
 }

--- a/src/InfluxDB.Collector/Configuration/CollectorEmitConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/CollectorEmitConfiguration.cs
@@ -5,11 +5,11 @@ namespace InfluxDB.Collector.Configuration
 {
     public abstract class CollectorEmitConfiguration
     {
-        public abstract CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null, string retentionPolicy = null);
+        public abstract CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null, bool enableCompression = false, string retentionPolicy = null);
 
-        public CollectorConfiguration InfluxDB(string serverBaseAddress, string database, string username = null, string password = null, string retentionPolicy = null)
+        public CollectorConfiguration InfluxDB(string serverBaseAddress, string database, string username = null, string password = null, bool enableCompression = false, string retentionPolicy = null)
         {
-            return InfluxDB(new Uri(serverBaseAddress), database, username, password, retentionPolicy);
+            return InfluxDB(new Uri(serverBaseAddress), database, username, password, enableCompression, retentionPolicy);
         }
 
         public abstract CollectorConfiguration Emitter(Action<PointData[]> emitter);

--- a/src/InfluxDB.Collector/Configuration/DelegateEmitter.cs
+++ b/src/InfluxDB.Collector/Configuration/DelegateEmitter.cs
@@ -17,5 +17,10 @@ namespace InfluxDB.Collector.Configuration
         {
             _emitter(points);
         }
+
+        public void Emit(PointData point)
+        {
+            _emitter(new [] { point });
+        }
     }
 }

--- a/src/InfluxDB.Collector/Configuration/PipelinedCollectorEmitConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/PipelinedCollectorEmitConfiguration.cs
@@ -20,12 +20,12 @@ namespace InfluxDB.Collector.Configuration
             _configuration = configuration;
         }
 
-        public override CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null, string retentionPolicy = null)
+        public override CollectorConfiguration InfluxDB(Uri serverBaseAddress, string database, string username = null, string password = null, bool enableCompression = false, string retentionPolicy = null)
         {
             if (string.Compare(serverBaseAddress.Scheme, "udp", ignoreCase: true) == 0)
                 _client = new LineProtocolUdpClient(serverBaseAddress, database, username, password, retentionPolicy);
             else
-                _client = new LineProtocolClient(serverBaseAddress, database, username, password, false, retentionPolicy);
+                _client = new LineProtocolClient(serverBaseAddress, database, username, password, enableCompression, retentionPolicy);
             return _configuration;
         }
 

--- a/src/InfluxDB.Collector/Configuration/PipelinedCollectorTagConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/PipelinedCollectorTagConfiguration.cs
@@ -24,6 +24,11 @@ namespace InfluxDB.Collector.Configuration
 
         public IPointEnricher CreateEnricher()
         {
+            if (_tags.Count == 0)
+            {
+                // if there are not tags makes no sense to enrich the dps so we skip
+                return null;
+            }
             return new DictionaryPointEnricher(_tags);
         }
     }

--- a/src/InfluxDB.Collector/InfluxDB.Collector.csproj
+++ b/src/InfluxDB.Collector/InfluxDB.Collector.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <ProjectReference Include="..\InfluxDB.LineProtocol\InfluxDB.LineProtocol.csproj" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />

--- a/src/InfluxDB.Collector/Metrics.cs
+++ b/src/InfluxDB.Collector/Metrics.cs
@@ -18,22 +18,22 @@ namespace InfluxDB.Collector
             }
         }
 
-        public static void Increment(string measurement, long value = 1, IReadOnlyDictionary<string, string> tags = null)
+        public static void Increment(string measurement, long value = 1, Dictionary<string, string> tags = null)
         {
             Collector.Increment(measurement, value, tags);
         }
 
-        public static void Measure(string measurement, object value, IReadOnlyDictionary<string, string> tags = null)
+        public static void Measure(string measurement, object value, Dictionary<string, string> tags = null)
         {
             Collector.Measure(measurement, value, tags);
         }
 
-        public static IDisposable Time(string measurement, IReadOnlyDictionary<string, string> tags = null)
+        public static IDisposable Time(string measurement, Dictionary<string, string> tags = null)
         {
             return Collector.Time(measurement, tags);
         }
 
-        public static void Write(string measurement, IReadOnlyDictionary<string, object> fields, IReadOnlyDictionary<string, string> tags = null)
+        public static void Write(string measurement, Dictionary<string, object> fields, Dictionary<string, string> tags = null)
         {
             Collector.Write(measurement, fields, tags);
         }

--- a/src/InfluxDB.Collector/MetricsCollector.cs
+++ b/src/InfluxDB.Collector/MetricsCollector.cs
@@ -9,17 +9,17 @@ namespace InfluxDB.Collector
     {
         readonly Util.ITimestampSource _timestampSource = new Util.PseudoHighResTimestampSource();
 
-        public void Increment(string measurement, long count = 1, IReadOnlyDictionary<string, string> tags = null)
+        public void Increment(string measurement, long count = 1, Dictionary<string, string> tags = null)
         {
             Write(measurement, new Dictionary<string, object> { { "count", count } }, tags);
         }
 
-        public void Measure(string measurement, object value, IReadOnlyDictionary<string, string> tags = null)
+        public void Measure(string measurement, object value, Dictionary<string, string> tags = null)
         {
             Write(measurement, new Dictionary<string, object> { { "value", value } }, tags);
         }
 
-        public IDisposable Time(string measurement, IReadOnlyDictionary<string, string> tags = null)
+        public IDisposable Time(string measurement, Dictionary<string, string> tags = null)
         {
             return new StopwatchTimer(this, measurement, tags);
         }
@@ -36,7 +36,7 @@ namespace InfluxDB.Collector
 
         protected virtual void Dispose(bool disposing) { }
 
-        public void Write(string measurement, IReadOnlyDictionary<string, object> fields, IReadOnlyDictionary<string, string> tags = null, DateTime? timestamp = null)
+        public void Write(string measurement, Dictionary<string, object> fields, Dictionary<string, string> tags = null, DateTime? timestamp = null)
         {
             try
             {

--- a/src/InfluxDB.Collector/MetricsCollector.cs
+++ b/src/InfluxDB.Collector/MetricsCollector.cs
@@ -41,7 +41,7 @@ namespace InfluxDB.Collector
             try
             {
                 var point = new PointData(measurement, fields, tags, timestamp ?? _timestampSource.GetUtcNow());
-                Emit(new[] { point });
+                Emit(point);
             }
             catch (Exception ex)
             {
@@ -54,6 +54,12 @@ namespace InfluxDB.Collector
             Emit(points);
         }
 
+        void IPointEmitter.Emit(PointData point)
+        {
+            Emit(point);
+        }
+
         protected abstract void Emit(PointData[] points);
+        protected abstract void Emit(PointData point);
     }
 }

--- a/src/InfluxDB.Collector/Pipeline/Batch/IntervalBatcher.cs
+++ b/src/InfluxDB.Collector/Pipeline/Batch/IntervalBatcher.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using InfluxDB.Collector.Diagnostics;
 using InfluxDB.Collector.Platform;
 using InfluxDB.Collector.Util;
@@ -10,33 +9,28 @@ namespace InfluxDB.Collector.Pipeline.Batch
 {
     class IntervalBatcher : IPointEmitter, IDisposable
     {
-        readonly object _queueLock = new object();
-        Queue<PointData> _queue = new Queue<PointData>();
-
-        readonly TimeSpan _interval;
-        readonly int? _maxBatchSize;
-        readonly IPointEmitter _parent;
-
-        readonly object _stateLock = new object();
-        readonly PortableTimer _timer;
         bool _unloading;
-        bool _started;
+        object _queueLock;
+        readonly int? _maxBatchSize;
+        readonly PortableTimer _timer;
+        readonly IPointEmitter _parent;
+        private Queue<PointData> _queue;
 
         public IntervalBatcher(TimeSpan interval, int? maxBatchSize, IPointEmitter parent)
         {
             _parent = parent;
-            _interval = interval;
+            _queueLock = new object();
             _maxBatchSize = maxBatchSize;
-            _timer = new PortableTimer(cancel => OnTick());
+            _queue = new Queue<PointData>();
+            _timer = new PortableTimer(cancel => OnTick(), interval);
         }
 
         void CloseAndFlush()
         {
-            lock (_stateLock)
+            lock (_queueLock)
             {
-                if (!_started || _unloading)
+                if (_unloading)
                     return;
-
                 _unloading = true;
             }
 
@@ -50,64 +44,70 @@ namespace InfluxDB.Collector.Pipeline.Batch
             CloseAndFlush();
         }
 
-        Task OnTick()
+        void OnTick()
         {
             try
             {
-                Queue<PointData> batch;
-                lock (_queueLock)
+                int count;
+                do
                 {
-                    if (_queue.Count == 0)
-                        return Task.Delay(0);
-
-                    batch = _queue;
-                    _queue = new Queue<PointData>();
-                }
-
-                if (_maxBatchSize == null || batch.Count <= _maxBatchSize.Value)
-                {
-                    _parent.Emit(batch.ToArray());
-                }
-                else
-                {
-                    foreach (var chunk in batch.Batch(_maxBatchSize.Value))
+                    Queue<PointData> batch;
+                    lock (_queueLock)
                     {
-                        _parent.Emit(chunk.ToArray());
+                        if (_queue.Count == 0)
+                        {
+                            // short cut
+                            return;
+                        }
+
+                        batch = _queue;
+                        _queue = new Queue<PointData>();
                     }
-                }
+
+                    if (batch.Count > _maxBatchSize * 5)
+                    {
+                        CollectorLog.ReportError($"InfluxDB.IntervalBatcher(): OnTick() Batch.Count: {batch.Count} lagging", null);
+                    }
+
+                    if (_maxBatchSize == null || batch.Count <= _maxBatchSize.Value)
+                    {
+                        _parent.Emit(batch.ToArray());
+                    }
+                    else
+                    {
+                        foreach (var chunk in batch.Batch(_maxBatchSize.Value))
+                        {
+                            _parent.Emit(chunk.ToArray());
+                        }
+                    }
+
+                    lock (_queueLock)
+                    {
+                        count = _queue.Count;
+                    }
+                    // if there is enough work let's directly loop again
+                } while (_maxBatchSize.HasValue && count >= _maxBatchSize.Value);
             }
             catch (Exception ex)
             {
                 CollectorLog.ReportError("Failed to emit metrics batch", ex);
             }
-            finally
-            {
-                lock (_stateLock)
-                {
-                    if (!_unloading)
-                        _timer.Start(_interval);
-                }
-            }
-
-            return Task.Delay(0);
         }
 
         public void Emit(PointData[] points)
         {
-            lock (_stateLock)
-            {
-                if (_unloading) return;
-                if (!_started)
-                {
-                    _started = true;
-                    _timer.Start(TimeSpan.Zero);
-                }
-            }
-
             lock (_queueLock)
             {
-                foreach(var point in points)
+                foreach (var point in points)
                     _queue.Enqueue(point);
+            }
+        }
+
+        public void Emit(PointData point)
+        {
+            lock (_queueLock)
+            {
+                _queue.Enqueue(point);
             }
         }
     }

--- a/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
+++ b/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using InfluxDB.Collector.Diagnostics;
 using InfluxDB.LineProtocol.Client;
 using InfluxDB.LineProtocol.Payload;
@@ -22,16 +23,16 @@ namespace InfluxDB.Collector.Pipeline.Emit
 
         public void Emit(PointData[] points)
         {
-            var payload = new LineProtocolPayload();
-
-            foreach (var point in points)
-            {
-                payload.Add(new LineProtocolPoint(point.Measurement, point.Fields, point.Tags, point.UtcTimestamp));
-            }
+            var payload = new LineProtocolPayload(points.Select(point => new LineProtocolPoint(point.Measurement, point.Fields, point.Tags, point.UtcTimestamp)));
 
             var influxResult = _client.WriteAsync(payload).Result;
             if (!influxResult.Success)
                 CollectorLog.ReportError(influxResult.ErrorMessage, null);
+        }
+
+        public void Emit(PointData point)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/InfluxDB.Collector/Pipeline/IPointEmitter.cs
+++ b/src/InfluxDB.Collector/Pipeline/IPointEmitter.cs
@@ -3,5 +3,7 @@
     interface IPointEmitter
     {
         void Emit(PointData[] points);
+
+        void Emit(PointData point);
     }
 }

--- a/src/InfluxDB.Collector/Pipeline/NullMetricsCollector.cs
+++ b/src/InfluxDB.Collector/Pipeline/NullMetricsCollector.cs
@@ -5,5 +5,9 @@
         protected override void Emit(PointData[] points)
         {
         }
+
+        protected override void Emit(PointData point)
+        {
+        }
     }
 }

--- a/src/InfluxDB.Collector/Pipeline/PipelinedMetricsCollector.cs
+++ b/src/InfluxDB.Collector/Pipeline/PipelinedMetricsCollector.cs
@@ -18,10 +18,20 @@ namespace InfluxDB.Collector.Pipeline
 
         protected override void Emit(PointData[] points)
         {
-            foreach (var point in points)
-                _enricher.Enrich(point);
+            if (_enricher != null)
+            {
+                foreach (var point in points)
+                    _enricher.Enrich(point);
+            }
 
             _emitter.Emit(points);
+        }
+
+        protected override void Emit(PointData point)
+        {
+            _enricher?.Enrich(point);
+
+            _emitter.Emit(point);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/InfluxDB.Collector/Pipeline/PointData.cs
+++ b/src/InfluxDB.Collector/Pipeline/PointData.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace InfluxDB.Collector.Pipeline
 {
@@ -13,16 +12,16 @@ namespace InfluxDB.Collector.Pipeline
 
         public PointData(
             string measurement,
-            IReadOnlyDictionary<string, object> fields,
-            IReadOnlyDictionary<string, string> tags = null,
+            Dictionary<string, object> fields,
+            Dictionary<string, string> tags = null,
             DateTime? utcTimestamp = null)
         {
             if (measurement == null) throw new ArgumentNullException(nameof(measurement));
             if (fields == null) throw new ArgumentNullException(nameof(fields));
+
             Measurement = measurement;
-            Fields = fields.ToDictionary(kv => kv.Key, kv => kv.Value);
-            if (tags != null)
-                Tags = tags.ToDictionary(kv => kv.Key, kv => kv.Value);
+            Fields = fields;
+            Tags = tags;
             UtcTimestamp = utcTimestamp;
         }
     }

--- a/src/InfluxDB.Collector/Platform/PortableTimer.cs
+++ b/src/InfluxDB.Collector/Platform/PortableTimer.cs
@@ -48,7 +48,7 @@ namespace InfluxDB.Collector.Platform
             {
                 try
                 {
-                    _cancel.Token.WaitHandle.WaitOne(_interval);
+                    Thread.Sleep(_interval);
                     if (!_cancel.IsCancellationRequested)
                     {
                         _onTick(_cancel.Token);

--- a/src/InfluxDB.Collector/StopwatchTimer.cs
+++ b/src/InfluxDB.Collector/StopwatchTimer.cs
@@ -9,9 +9,9 @@ namespace InfluxDB.Collector
         readonly Stopwatch _stopwatch = new Stopwatch();
         readonly MetricsCollector _collector;
         readonly string _measurement;
-        readonly IReadOnlyDictionary<string, string> _tags;
+        readonly Dictionary<string, string> _tags;
 
-        public StopwatchTimer(MetricsCollector collector, string measurement, IReadOnlyDictionary<string, string> tags = null)
+        public StopwatchTimer(MetricsCollector collector, string measurement, Dictionary<string, string> tags = null)
         {
             _collector = collector;
             _measurement = measurement;

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolClient.cs
@@ -44,30 +44,32 @@ namespace InfluxDB.LineProtocol.Client
             Precision precision,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var endpoint = $"write?db={Uri.EscapeDataString(_database)}";
+            var stringBuilder = new StringBuilder(50);
+            stringBuilder.Append($"write?db={Uri.EscapeDataString(_database)}");
             if (!string.IsNullOrWhiteSpace(_retentionPolicy))
-                endpoint += $"&rp={Uri.EscapeDataString(_retentionPolicy)}";
+                stringBuilder.Append($"&rp={Uri.EscapeDataString(_retentionPolicy)}");
             if (!string.IsNullOrEmpty(_username))
-                endpoint += $"&u={Uri.EscapeDataString(_username)}&p={Uri.EscapeDataString(_password)}";
+                stringBuilder.Append($"&u={Uri.EscapeDataString(_username)}&p={Uri.EscapeDataString(_password)}");
 
             switch (precision)
             {
                 case Precision.Microseconds:
-                    endpoint += "&precision=u";
+                    stringBuilder.Append("&precision=u");
                     break;
                 case Precision.Milliseconds:
-                    endpoint += "&precision=ms";
+                    stringBuilder.Append("&precision=ms");
                     break;
                 case Precision.Seconds:
-                    endpoint += "&precision=s";
+                    stringBuilder.Append("&precision=s");
                     break;
                 case Precision.Minutes:
-                    endpoint += "&precision=m";
+                    stringBuilder.Append("&precision=m");
                     break;
                 case Precision.Hours:
-                    endpoint += "&precision=h";
+                    stringBuilder.Append("&precision=h");
                     break;
             }
+            var endpoint = stringBuilder.ToString();
 
             HttpContent content;
 

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolPayload.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolPayload.cs
@@ -1,17 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace InfluxDB.LineProtocol.Payload
 {
     public class LineProtocolPayload
     {
-        readonly List<LineProtocolPoint> _points = new List<LineProtocolPoint>();
+        IEnumerable<LineProtocolPoint> _points;
+
+        public LineProtocolPayload(IEnumerable<LineProtocolPoint> points = null)
+        {
+            _points = points ?? Enumerable.Empty<LineProtocolPoint>();
+        }
 
         public void Add(LineProtocolPoint point)
         {
             if (point == null) throw new ArgumentNullException(nameof(point));
-            _points.Add(point);
+            _points = _points.Concat(new []{ point });
         }
 
         public void Format(TextWriter textWriter)

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolPoint.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolPoint.cs
@@ -21,13 +21,6 @@ namespace InfluxDB.LineProtocol.Payload
             if (string.IsNullOrEmpty(measurement)) throw new ArgumentException("A measurement name must be specified");
             if (fields == null || fields.Count == 0) throw new ArgumentException("At least one field must be specified");
 
-            foreach (var f in fields)
-                if (string.IsNullOrEmpty(f.Key)) throw new ArgumentException("Fields must have non-empty names");
-
-            if (tags != null)
-                foreach (var t in tags)
-                    if (string.IsNullOrEmpty(t.Key)) throw new ArgumentException("Tags must have non-empty names");
-
             if (utcTimestamp != null && utcTimestamp.Value.Kind != DateTimeKind.Utc)
                 throw new ArgumentException("Timestamps must be specified as UTC");
 
@@ -45,32 +38,30 @@ namespace InfluxDB.LineProtocol.Payload
 
             if (Tags != null)
             {
-                foreach (var t in Tags.OrderBy(t => t.Key))
-                {
-                    if (t.Value == null || t.Value == "")
-                        continue;
+                var enumerable = Tags.Count == 1
+                    ? (IEnumerable<KeyValuePair<string, string>>) Tags
+                    : Tags.OrderBy(t => t.Key);
 
-                    textWriter.Write(',');
-                    textWriter.Write(LineProtocolSyntax.EscapeName(t.Key));
-                    textWriter.Write('=');
-                    textWriter.Write(LineProtocolSyntax.EscapeName(t.Value));
+                foreach (var t in enumerable)
+                {
+                    if (string.IsNullOrEmpty(t.Key)) throw new ArgumentException("Tags must have non-empty names");
+
+                    textWriter.Write($",{LineProtocolSyntax.EscapeName(t.Key)}={LineProtocolSyntax.EscapeName(t.Value)}");
                 }
             }
 
             var fieldDelim = ' ';
             foreach (var f in Fields)
             {
-                textWriter.Write(fieldDelim);
+                if (string.IsNullOrEmpty(f.Key)) throw new ArgumentException("Fields must have non-empty names");
+
+                textWriter.Write($"{fieldDelim}{LineProtocolSyntax.EscapeName(f.Key)}={LineProtocolSyntax.FormatValue(f.Value)}");
                 fieldDelim = ',';
-                textWriter.Write(LineProtocolSyntax.EscapeName(f.Key));
-                textWriter.Write('=');
-                textWriter.Write(LineProtocolSyntax.FormatValue(f.Value));
             }
 
             if (UtcTimestamp != null)
             {
-                textWriter.Write(' ');
-                textWriter.Write(LineProtocolSyntax.FormatTimestamp(UtcTimestamp.Value));
+                textWriter.Write($" {LineProtocolSyntax.FormatTimestamp(UtcTimestamp.Value)}");
             }
         }
     }

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 
 namespace InfluxDB.LineProtocol.Payload
 {
@@ -28,10 +29,27 @@ namespace InfluxDB.LineProtocol.Payload
         public static string EscapeName(string nameOrKey)
         {
             if (nameOrKey == null) throw new ArgumentNullException(nameof(nameOrKey));
-            return nameOrKey
-                .Replace("=", "\\=")
-                .Replace(" ", "\\ ")
-                .Replace(",", "\\,");
+
+            var stringBuilder = new StringBuilder(nameOrKey.Length);
+            foreach (var character in nameOrKey)
+            {
+                switch (character)
+                {
+                    case '=':
+                        stringBuilder.Append("\\=");
+                        break;
+                    case ' ':
+                        stringBuilder.Append("\\ ");
+                        break;
+                    case ',':
+                        stringBuilder.Append("\\,");
+                        break;
+                    default:
+                        stringBuilder.Append(character);
+                        break;
+                }
+            }
+            return stringBuilder.ToString();
         }
 
         public static string FormatValue(object value)

--- a/test/InfluxDB.LineProtocol.Tests/Collector/MetricsCollectorTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Collector/MetricsCollectorTests.cs
@@ -52,7 +52,6 @@ namespace InfluxDB.LineProtocol.Tests.Collector
                 .CreateCollector();
 
             collector.Increment("m");
-            written.Task.Wait();
 
             collector.Dispose();
         }


### PR DESCRIPTION
- Refactor IntervalBatcher for performance, use a set of dedicated threads to emit datapoints. Clean up and simplification.
- Allow emitting a single data point instead of an array.
- Skip call to Enricher if not used.