### PR TITLE
Performance improvements

### DIFF
--- a/src/InfluxDB.Collector/Configuration/CollectorBatchConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/CollectorBatchConfiguration.cs
@@ -4,8 +4,8 @@ namespace InfluxDB.Collector.Configuration
 {
     public abstract class CollectorBatchConfiguration
     {
-        public CollectorConfiguration AtInterval(TimeSpan interval) => AtInterval(interval, 5000);
+        public CollectorConfiguration AtInterval(TimeSpan interval) => AtInterval(interval, 5000, 4);
 
-        public abstract CollectorConfiguration AtInterval(TimeSpan interval, int? maxBatchSize);
+        public abstract CollectorConfiguration AtInterval(TimeSpan interval, int? maxBatchSize, int? workers);
     }
 }

--- a/src/InfluxDB.Collector/Configuration/PipelinedCollectorBatchConfiguration.cs
+++ b/src/InfluxDB.Collector/Configuration/PipelinedCollectorBatchConfiguration.cs
@@ -9,6 +9,7 @@ namespace InfluxDB.Collector.Configuration
         readonly CollectorConfiguration _configuration;
         TimeSpan? _interval;
         int? _maxBatchSize;
+        int? _workers;
 
         public PipelinedCollectorBatchConfiguration(CollectorConfiguration configuration)
         {
@@ -16,8 +17,9 @@ namespace InfluxDB.Collector.Configuration
             _configuration = configuration;
         }
 
-        public override CollectorConfiguration AtInterval(TimeSpan interval, int? maxBatchSize)
+        public override CollectorConfiguration AtInterval(TimeSpan interval, int? maxBatchSize, int? workers)
         {
+            _workers = workers;
             _interval = interval;
             _maxBatchSize = maxBatchSize;
             return _configuration;
@@ -31,7 +33,7 @@ namespace InfluxDB.Collector.Configuration
                 return parent;
             }
 
-            var batcher = new IntervalBatcher(_interval.Value, _maxBatchSize, parent);
+            var batcher = new IntervalBatcher(_interval.Value, _maxBatchSize, _workers, parent);
             dispose = batcher.Dispose;
             return batcher;
         }

--- a/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
+++ b/src/InfluxDB.Collector/Pipeline/Emit/HttpLineProtocolEmitter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using InfluxDB.Collector.Diagnostics;
 using InfluxDB.LineProtocol.Client;
 using InfluxDB.LineProtocol.Payload;
@@ -9,6 +10,10 @@ namespace InfluxDB.Collector.Pipeline.Emit
     class HttpLineProtocolEmitter : IDisposable, IPointEmitter
     {
         readonly ILineProtocolClient _client;
+
+        private static DateTime _lastReport;
+        private static int _globalCounter;
+        private static int _emitCount;
 
         public HttpLineProtocolEmitter(ILineProtocolClient client)
         {
@@ -24,8 +29,25 @@ namespace InfluxDB.Collector.Pipeline.Emit
         public void Emit(List<IPointData> points)
         {
             var influxResult = _client.WriteAsync(points);
+
+            Interlocked.Add(ref _globalCounter, points.Count / 1000);
+
             if (!influxResult.Success)
+            {
                 CollectorLog.ReportError(influxResult.ErrorMessage, null);
+            }
+            else
+            {
+                if (Interlocked.Increment(ref _emitCount) % 500 == 0)
+                {
+                    var now = DateTime.UtcNow;
+                    if (now - _lastReport > TimeSpan.FromSeconds(10))
+                    {
+                        _lastReport = now;
+                        CollectorLog.Report($"Influxdb pushed: {_globalCounter}K");
+                    }
+                }
+            }
         }
 
         public void Emit(IPointData point)

--- a/src/InfluxDB.LineProtocol/Client/ILineProtocolClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/ILineProtocolClient.cs
@@ -9,6 +9,6 @@ namespace InfluxDB.LineProtocol.Client
     {
         Task<LineProtocolWriteResult> SendAsync(LineProtocolWriter lineProtocolWriter, CancellationToken cancellationToken = default);
         LineProtocolWriteResult WriteAsync(List<IPointData> payload, CancellationToken cancellationToken = default);
-        Task<LineProtocolWriteResult> WriteAsync(string payload, CancellationToken cancellationToken = default);
+        Task<LineProtocolWriteResult> WriteAsync(byte[] payload, CancellationToken cancellationToken = default);
     }
 }

--- a/src/InfluxDB.LineProtocol/Client/LineProtocolUdpClient.cs
+++ b/src/InfluxDB.LineProtocol/Client/LineProtocolUdpClient.cs
@@ -1,10 +1,5 @@
-﻿using InfluxDB.LineProtocol.Payload;
-using System;
-using System.IO;
-using System.Net;
-using System.Net.Http;
+﻿using System;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,11 +30,10 @@ namespace InfluxDB.LineProtocol.Client
         }
 
         protected override async Task<LineProtocolWriteResult> OnSendAsync(
-                                    string payload,
+                                    byte[] buffer,
                                     Precision precision,
                                     CancellationToken cancellationToken = default(CancellationToken))
         {
-            var buffer = Encoding.UTF8.GetBytes(payload);
             int len = await _udpClient.SendAsync(buffer, buffer.Length, _udpHostName, _udpPort);
             return new LineProtocolWriteResult(len == buffer.Length, null);
         }

--- a/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
+++ b/src/InfluxDB.LineProtocol/InfluxDB.LineProtocol.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>A .NET library for efficiently sending time series to InfluxDB</Description>
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolPayload.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolPayload.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 
@@ -79,7 +80,14 @@ namespace InfluxDB.LineProtocol.Payload
                 textWriter.Write(fieldDelim);
                 LineProtocolSyntax.EscapeName(kvp.Key, textWriter);
                 textWriter.Write('=');
-                textWriter.Write(LineProtocolSyntax.FormatValue(kvp.Value));
+                if (kvp.Value is decimal value)
+                {
+                    textWriter.Write(value.ToString(NumberFormatInfo.InvariantInfo));
+                }
+                else
+                {
+                    textWriter.Write(LineProtocolSyntax.FormatValue(kvp.Value));
+                }
 
                 fieldDelim = ',';
             }

--- a/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
+++ b/src/InfluxDB.LineProtocol/Payload/LineProtocolSyntax.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace InfluxDB.LineProtocol.Payload
 {
@@ -26,6 +27,7 @@ namespace InfluxDB.LineProtocol.Payload
             { typeof(TimeSpan), FormatTimespan }
         };
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void EscapeName(string nameOrKey, TextWriter textWriter)
         {
             if (nameOrKey == null) throw new ArgumentNullException(nameof(nameOrKey));
@@ -84,10 +86,11 @@ namespace InfluxDB.LineProtocol.Payload
             return "\"" + s.Replace("\\", "\\\\").Replace("\"", "\\\"") + "\"";
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string FormatTimestamp(DateTime utcTimestamp)
         {
             var t = utcTimestamp - Origin;
-            return (t.Ticks * 100L).ToString(CultureInfo.InvariantCulture);
+            return (t.Ticks * 100L).ToString(NumberFormatInfo.InvariantInfo);
         }
     }
 }

--- a/test/InfluxDB.LineProtocol.Tests/Payload/LineProtocolPayloadTests.cs
+++ b/test/InfluxDB.LineProtocol.Tests/Payload/LineProtocolPayloadTests.cs
@@ -81,5 +81,27 @@ namespace InfluxDB.LineProtocol.Tests
             Assert.Equal(expected, sw.ToString());
         }
 
+        [Fact]
+        public void Decimal()
+        {
+            var point = new LineProtocolPayload(new IPointData[]{ new PointData(
+                "pinocho",
+                new[]
+                {
+                    new KeyValuePair<string, object>("value", 1090213.0000m)
+                },
+                new[]
+                {
+                    new KeyValuePair<string, string>("symbol", "test")
+                },
+                new DateTime(2015, 9, 9, 0, 0, 0, DateTimeKind.Utc)) });
+
+            var sw = new StringWriter();
+            point.Format(sw);
+
+            var result = sw.ToString();
+
+            Assert.Equal("pinocho,symbol=test value=1090213.0000 1441756800000000000\n", sw.ToString());
+        }
     }
 }


### PR DESCRIPTION
- Use `RecyclableMemoryStreamManager` to re use memory streams.
- Use http binary contect to avoid ToString() operation.
- Expose configuration for `IntervalBatcher` number of workers.
- Workers at `IntervalBatcher` will reuse `Queue` instance.
- Add new report callback with currently pushed data points